### PR TITLE
refactor: :hammer: Modularize LLM service and prompt logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,10 @@
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
+mod models;
+mod services;
+mod prompt;
+
 use std::io::{self, Read};
-use std::env;
-use tokio;
-
-#[derive(Serialize)]
-struct OllamaRequest {
-    model: String,
-    prompt: String,
-    stream: bool,
-}
-
-#[derive(Deserialize, Debug)]
-struct OllamaResponse {
-    response: String,
-}
+use services::LlmService;
+use services::ollama::OllamaService;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -27,128 +17,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    // Construct prompt for the LLM
-    let prompt = format!(
-        "Generate a Git commit message with its description and an appropriate emoji based on the provided Git diff.
+    // Create prompt
+    let prompt = prompt::create_commit_message_prompt(&diff);
 
-        **Rules:**
-        - Respond with only the commit message and description.
-        - No explanations, no markdown formatting, no code block (```) wrappers.
-        - Follow this format:
-
-        `<type>: <emoji><message>`  
-        `<detailed description>`
-
-        **Example output:**
-
-        feat: 🎉Initial commit  
-        Initial commit description
-
-        **Commit types and corresponding emojis:**
-
-        | Type                        | Emoji             |
-        |-----------------------------|-------------------|
-        | Initial commit              | 🎉 `:tada:`        |
-        | Version tag                 | 🔖 `:bookmark:`    |
-        | New feature                 | ✨ `:sparkles:`     |
-        | Bugfix                      | 🐛 `:bug:`         |
-        | Metadata                    | 📇 `:card_index:`  |
-        | Documentation               | 📚 `:books:`       |
-        | Documenting source code     | 💡 `:bulb:`        |
-        | Performance                 | 🐎 `:racehorse:`   |
-        | Cosmetic                    | 💄 `:lipstick:`    |
-        | Tests                       | 🚨 `:rotating_light:` |
-        | Adding a test               | ✅ `:white_check_mark:` |
-        | Make a test pass            | ✔️ `:heavy_check_mark:` |
-        | General update              | ⚡ `:zap:`          |
-        | Improve format/structure    | 🎨 `:art:`         |
-        | Refactor code               | 🔨 `:hammer:`      |
-        | Removing code/files         | 🔥 `:fire:`        |
-        | Continuous Integration      | 💚 `:green_heart:` |
-        | Security                    | 🔒 `:lock:`        |
-        | Upgrading dependencies      | ⬆️ `:arrow_up:`     |
-        | Downgrading dependencies    | ⬇️ `:arrow_down:`   |
-        | Lint                        | 👕 `:shirt:`       |
-        | Translation                 | 👽 `:alien:`       |
-        | Text                        | ✏️ `:pencil:`       |
-        | Critical hotfix             | 🚑 `:ambulance:`   |
-        | Deploying stuff             | 🚀 `:rocket:`      |
-        | Fixing on MacOS             | 🍎 `:apple:`       |
-        | Fixing on Linux             | 🐧 `:penguin:`     |
-        | Fixing on Windows           | 🏁 `:checkered_flag:` |
-        | Work in progress            | 🚧 `:construction:` |
-        | Adding CI build system      | 👷 `:construction_worker:` |
-        | Analytics or tracking code  | 📈 `:chart_with_upwards_trend:` |
-        | Removing a dependency       | ➖ `:heavy_minus_sign:` |
-        | Adding a dependency         | ➕ `:heavy_plus_sign:` |
-        | Docker                      | 🐳 `:whale:`        |
-        | Configuration files         | 🔧 `:wrench:`       |
-        | Package.json in JS          | 📦 `:package:`      |
-        | Merging branches            | 🔀 `:twisted_rightwards_arrows:` |
-        | Bad code / needs improvement| 💩 `:hankey:`       |
-        | Reverting changes           | ⏪ `:rewind:`       |
-        | Breaking changes            | 💥 `:boom:`         |
-        | Code review changes         | 👌 `:ok_hand:`      |
-        | Accessibility               | ♿ `:wheelchair:`   |
-        | Move/rename repository      | 🚚 `:truck:`        |
-
-        Now respond with the commit message for the following Git diff:\n\n{}",
-            diff
-        );
-
-    let commit_message = generate_with_ollama(&prompt).await?;
+    // Initialize Ollama service
+    let llm_service = OllamaService::new();
+    
+    // Generate commit message
+    let commit_message = llm_service.generate(&prompt).await?;
 
     // Output the commit message to stdout
     println!("{}", commit_message.trim());
 
     Ok(())
-}
-
-async fn generate_with_ollama(prompt: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let client = Client::new();
-    let ollama_model = env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3".to_string());
-    
-    let response = match client
-        .post("http://localhost:11434/api/generate")
-        .json(&OllamaRequest {
-            model: ollama_model.clone(),
-            prompt: prompt.to_string(),
-            stream: false,
-        })
-        .send()
-        .await {
-            Ok(resp) => {
-                if resp.status().is_success() {
-                    resp
-                } else {
-                    if resp.status() == reqwest::StatusCode::NOT_FOUND {
-                        eprintln!("Error: Model '{}' not found on the Ollama server", ollama_model);
-                        eprintln!("To install {}: ollama pull {}", ollama_model, ollama_model);
-                        eprintln!("Or set OLLAMA_MODEL environment variable to use a different model");
-                    } else {
-                        eprintln!("Error from Ollama server: Status {}", resp.status());
-                    }
-                    return Err(format!("Ollama server error: {}", resp.status()).into());
-                }
-            }
-            Err(e) => {
-                if e.is_connect() {
-                    eprintln!("Error: Could not connect to Ollama server at http://localhost:11434");
-                    eprintln!("Please make sure the Ollama server is running");
-                } else {
-                    eprintln!("Error sending request to Ollama server: {}", e);
-                }
-                return Err(Box::new(e));
-            }
-        };
-
-    let ollama_response: OllamaResponse = match response.json().await {
-        Ok(parsed) => parsed,
-        Err(e) => {
-            eprintln!("Error parsing response from Ollama server: {}", e);
-            return Err(Box::new(e));
-        }
-    };
-
-    Ok(ollama_response.response)
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct OllamaRequest {
+    pub model: String,
+    pub prompt: String,
+    pub stream: bool,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct OllamaResponse {
+    pub response: String,
+}

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,69 @@
+pub fn create_commit_message_prompt(diff: &str) -> String {
+    format!(
+        "Generate a Git commit message with its description and an appropriate emoji based on the provided Git diff.
+
+        **Rules:**
+        - Respond with only the commit message and description.
+        - No explanations, no markdown formatting, no code block (```) wrappers.
+        - Follow this format:
+
+        `<type>: <emoji><message>`  
+        `<detailed description>`
+
+        **Example output:**
+
+        feat: 🎉Initial commit  
+        Initial commit description
+
+        **Commit types and corresponding emojis:**
+
+        | Type                        | Emoji             |
+        |-----------------------------|-------------------|
+        | Initial commit              | 🎉 `:tada:`        |
+        | Version tag                 | 🔖 `:bookmark:`    |
+        | New feature                 | ✨ `:sparkles:`     |
+        | Bugfix                      | 🐛 `:bug:`         |
+        | Metadata                    | 📇 `:card_index:`  |
+        | Documentation               | 📚 `:books:`       |
+        | Documenting source code     | 💡 `:bulb:`        |
+        | Performance                 | 🐎 `:racehorse:`   |
+        | Cosmetic                    | 💄 `:lipstick:`    |
+        | Tests                       | 🚨 `:rotating_light:` |
+        | Adding a test               | ✅ `:white_check_mark:` |
+        | Make a test pass            | ✔️ `:heavy_check_mark:` |
+        | General update              | ⚡ `:zap:`          |
+        | Improve format/structure    | 🎨 `:art:`         |
+        | Refactor code               | 🔨 `:hammer:`      |
+        | Removing code/files         | 🔥 `:fire:`        |
+        | Continuous Integration      | 💚 `:green_heart:` |
+        | Security                    | 🔒 `:lock:`        |
+        | Upgrading dependencies      | ⬆️ `:arrow_up:`     |
+        | Downgrading dependencies    | ⬇️ `:arrow_down:`   |
+        | Lint                        | 👕 `:shirt:`       |
+        | Translation                 | 👽 `:alien:`       |
+        | Text                        | ✏️ `:pencil:`       |
+        | Critical hotfix             | 🚑 `:ambulance:`   |
+        | Deploying stuff             | 🚀 `:rocket:`      |
+        | Fixing on MacOS             | 🍎 `:apple:`       |
+        | Fixing on Linux             | 🐧 `:penguin:`     |
+        | Fixing on Windows           | 🏁 `:checkered_flag:` |
+        | Work in progress            | 🚧 `:construction:` |
+        | Adding CI build system      | 👷 `:construction_worker:` |
+        | Analytics or tracking code  | 📈 `:chart_with_upwards_trend:` |
+        | Removing a dependency       | ➖ `:heavy_minus_sign:` |
+        | Adding a dependency         | ➕ `:heavy_plus_sign:` |
+        | Docker                      | 🐳 `:whale:`        |
+        | Configuration files         | 🔧 `:wrench:`       |
+        | Package.json in JS          | 📦 `:package:`      |
+        | Merging branches            | 🔀 `:twisted_rightwards_arrows:` |
+        | Bad code / needs improvement| 💩 `:hankey:`       |
+        | Reverting changes           | ⏪ `:rewind:`       |
+        | Breaking changes            | 💥 `:boom:`         |
+        | Code review changes         | 👌 `:ok_hand:`      |
+        | Accessibility               | ♿ `:wheelchair:`   |
+        | Move/rename repository      | 🚚 `:truck:`        |
+
+        Now respond with the commit message for the following Git diff:\n\n{}",
+        diff
+    )
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,6 @@
+pub mod ollama;
+
+// Trait for any LLM service
+pub trait LlmService {
+    async fn generate(&self, prompt: &str) -> Result<String, Box<dyn std::error::Error>>;
+}

--- a/src/services/ollama.rs
+++ b/src/services/ollama.rs
@@ -1,0 +1,66 @@
+use crate::models::{OllamaRequest, OllamaResponse};
+use crate::services::LlmService;
+use reqwest::Client;
+use std::env;
+
+pub struct OllamaService {
+    client: Client,
+}
+
+impl OllamaService {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+}
+
+impl LlmService for OllamaService {
+    async fn generate(&self, prompt: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let ollama_model = env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3".to_string());
+        
+        let response = match self.client
+            .post("http://localhost:11434/api/generate")
+            .json(&OllamaRequest {
+                model: ollama_model.clone(),
+                prompt: prompt.to_string(),
+                stream: false,
+            })
+            .send()
+            .await {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        resp
+                    } else {
+                        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+                            eprintln!("Error: Model '{}' not found on the Ollama server", ollama_model);
+                            eprintln!("To install {}: ollama pull {}", ollama_model, ollama_model);
+                            eprintln!("Or set OLLAMA_MODEL environment variable to use a different model");
+                        } else {
+                            eprintln!("Error from Ollama server: Status {}", resp.status());
+                        }
+                        return Err(format!("Ollama server error: {}", resp.status()).into());
+                    }
+                }
+                Err(e) => {
+                    if e.is_connect() {
+                        eprintln!("Error: Could not connect to Ollama server at http://localhost:11434");
+                        eprintln!("Please make sure the Ollama server is running");
+                    } else {
+                        eprintln!("Error sending request to Ollama server: {}", e);
+                    }
+                    return Err(Box::new(e));
+                }
+            };
+
+        let ollama_response: OllamaResponse = match response.json().await {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                eprintln!("Error parsing response from Ollama server: {}", e);
+                return Err(Box::new(e));
+            }
+        };
+
+        Ok(ollama_response.response)
+    }
+}


### PR DESCRIPTION
- Split main logic into dedicated modules (`models`, `services`, `prompt`)
- Introduced `LlmService` trait for extensibility
- Extracted Ollama-specific code into `OllamaService` implementation
- Moved prompt generation to separate `prompt` module
- Maintained same functionality with cleaner architecture